### PR TITLE
Dev/q55mehqs

### DIFF
--- a/SugorokuLibrary/ClientToServer/CloseCreateMessage.cs
+++ b/SugorokuLibrary/ClientToServer/CloseCreateMessage.cs
@@ -14,5 +14,11 @@ namespace SugorokuLibrary.ClientToServer
 		{
 			MatchKey = matchKey;
 		}
+
+		public override bool Equals(object? obj)
+		{
+			if (!(obj is CloseCreateMessage cl)) return false;
+			return cl.MatchKey == MatchKey;
+		}
 	}
 }

--- a/SugorokuLibrary/ClientToServer/Converters/ClientMessageConverter.cs
+++ b/SugorokuLibrary/ClientToServer/Converters/ClientMessageConverter.cs
@@ -21,6 +21,7 @@ namespace SugorokuLibrary.ClientToServer.Converters
 				"getMatchInfo" => new GetMatchInfoConverter(),
 				"getAllMatches" => new GetAllMatchesConverter(),
 				"dice" => new DiceMessageConverter(),
+				"prevDice" => new PrevDiceMessageConverter(),
 				_ => throw new ArgumentException()
 			};
 			var newReader = jObject.CreateReader();

--- a/SugorokuLibrary/ClientToServer/Converters/DiceMessageConverter.cs
+++ b/SugorokuLibrary/ClientToServer/Converters/DiceMessageConverter.cs
@@ -30,7 +30,7 @@ namespace SugorokuLibrary.ClientToServer.Converters
 
 		public override bool CanConvert(Type objectType)
 		{
-			return objectType == typeof(GetAllMatchesMessage);
+			return objectType == typeof(DiceMessage);
 		}
 	}
 }

--- a/SugorokuLibrary/ClientToServer/Converters/DiceMessageConverter.cs
+++ b/SugorokuLibrary/ClientToServer/Converters/DiceMessageConverter.cs
@@ -17,8 +17,6 @@ namespace SugorokuLibrary.ClientToServer.Converters
 			writer.WriteValue(diceMessage.MatchKey);
 			writer.WritePropertyName("playerId");
 			writer.WriteValue(diceMessage.PlayerId);
-			writer.WritePropertyName("nowPosition");
-			writer.WriteValue(diceMessage.NowPosition);
 			writer.WriteEndObject();
 		}
 
@@ -26,8 +24,7 @@ namespace SugorokuLibrary.ClientToServer.Converters
 			JsonSerializer serializer)
 		{
 			JObject jObject = JObject.Load(reader);
-			return new DiceMessage((string) jObject["matchKey"]!, (int) jObject["playerId"]!,
-				(int) jObject["nowPosition"]!);
+			return new DiceMessage((string) jObject["matchKey"]!, (int) jObject["playerId"]!);
 		}
 
 		public override bool CanConvert(Type objectType)

--- a/SugorokuLibrary/ClientToServer/Converters/DiceMessageConverter.cs
+++ b/SugorokuLibrary/ClientToServer/Converters/DiceMessageConverter.cs
@@ -11,8 +11,10 @@ namespace SugorokuLibrary.ClientToServer.Converters
 			var diceMessage = (DiceMessage) value!;
 
 			writer.WriteStartObject();
-			writer.WritePropertyName("matchId");
-			writer.WriteValue(diceMessage.MatchId);
+			writer.WritePropertyName("methodType");
+			writer.WriteValue(diceMessage.MethodType);
+			writer.WritePropertyName("matchKey");
+			writer.WriteValue(diceMessage.MatchKey);
 			writer.WritePropertyName("playerId");
 			writer.WriteValue(diceMessage.PlayerId);
 			writer.WritePropertyName("nowPosition");
@@ -24,7 +26,7 @@ namespace SugorokuLibrary.ClientToServer.Converters
 			JsonSerializer serializer)
 		{
 			JObject jObject = JObject.Load(reader);
-			return new DiceMessage((string) jObject["matchId"]!, (int) jObject["playerId"]!,
+			return new DiceMessage((string) jObject["matchKey"]!, (int) jObject["playerId"]!,
 				(int) jObject["nowPosition"]!);
 		}
 

--- a/SugorokuLibrary/ClientToServer/Converters/PrevDiceMessageConverter.cs
+++ b/SugorokuLibrary/ClientToServer/Converters/PrevDiceMessageConverter.cs
@@ -17,8 +17,6 @@ namespace SugorokuLibrary.ClientToServer.Converters
             writer.WriteValue(diceMessage.MatchKey);
             writer.WritePropertyName("playerId");
             writer.WriteValue(diceMessage.PlayerId);
-            writer.WritePropertyName("nowPosition");
-            writer.WriteValue(diceMessage.NowPosition);
             writer.WriteEndObject();
         }
 
@@ -26,8 +24,7 @@ namespace SugorokuLibrary.ClientToServer.Converters
             JsonSerializer serializer)
         {
             JObject jObject = JObject.Load(reader);
-            return new PrevDiceMessage((string) jObject["matchKey"]!, (int) jObject["playerId"]!,
-                (int) jObject["nowPosition"]!);
+            return new PrevDiceMessage((string) jObject["matchKey"]!, (int) jObject["playerId"]!);
         }
 
         public override bool CanConvert(Type objectType)

--- a/SugorokuLibrary/ClientToServer/Converters/PrevDiceMessageConverter.cs
+++ b/SugorokuLibrary/ClientToServer/Converters/PrevDiceMessageConverter.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace SugorokuLibrary.ClientToServer.Converters
+{
+    public class PrevDiceMessageConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+        {
+            var diceMessage = (PrevDiceMessage) value!;
+
+            writer.WriteStartObject();
+            writer.WritePropertyName("matchId");
+            writer.WriteValue(diceMessage.MatchId);
+            writer.WritePropertyName("playerId");
+            writer.WriteValue(diceMessage.PlayerId);
+            writer.WritePropertyName("nowPosition");
+            writer.WriteValue(diceMessage.NowPosition);
+            writer.WriteEndObject();
+        }
+
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue,
+            JsonSerializer serializer)
+        {
+            JObject jObject = JObject.Load(reader);
+            return new PrevDiceMessage((string) jObject["matchId"]!, (int) jObject["playerId"]!,
+                (int) jObject["nowPosition"]!);
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(PrevDiceMessage);
+        }
+    }
+}

--- a/SugorokuLibrary/ClientToServer/Converters/PrevDiceMessageConverter.cs
+++ b/SugorokuLibrary/ClientToServer/Converters/PrevDiceMessageConverter.cs
@@ -11,8 +11,10 @@ namespace SugorokuLibrary.ClientToServer.Converters
             var diceMessage = (PrevDiceMessage) value!;
 
             writer.WriteStartObject();
-            writer.WritePropertyName("matchId");
-            writer.WriteValue(diceMessage.MatchId);
+            writer.WritePropertyName("methodType");
+            writer.WriteValue(diceMessage.MethodType);
+            writer.WritePropertyName("matchKey");
+            writer.WriteValue(diceMessage.MatchKey);
             writer.WritePropertyName("playerId");
             writer.WriteValue(diceMessage.PlayerId);
             writer.WritePropertyName("nowPosition");
@@ -24,7 +26,7 @@ namespace SugorokuLibrary.ClientToServer.Converters
             JsonSerializer serializer)
         {
             JObject jObject = JObject.Load(reader);
-            return new PrevDiceMessage((string) jObject["matchId"]!, (int) jObject["playerId"]!,
+            return new PrevDiceMessage((string) jObject["matchKey"]!, (int) jObject["playerId"]!,
                 (int) jObject["nowPosition"]!);
         }
 

--- a/SugorokuLibrary/ClientToServer/CreatePlayerMessage.cs
+++ b/SugorokuLibrary/ClientToServer/CreatePlayerMessage.cs
@@ -17,5 +17,11 @@ namespace SugorokuLibrary.ClientToServer
 			PlayerName = playerName;
 			MatchKey = matchKey;
 		}
+
+		public override bool Equals(object? obj)
+		{
+			if (!(obj is CreatePlayerMessage cr)) return false;
+			return cr.MatchKey == MatchKey && cr.PlayerName == PlayerName;
+		}
 	}
 }

--- a/SugorokuLibrary/ClientToServer/DiceMessage.cs
+++ b/SugorokuLibrary/ClientToServer/DiceMessage.cs
@@ -9,19 +9,17 @@ namespace SugorokuLibrary.ClientToServer
 		[JsonProperty("methodType")] public string MethodType => "dice";
 		[JsonProperty("matchKey")] public string MatchKey { get; }
 		[JsonProperty("playerId")] public int PlayerId { get; }
-		[JsonProperty("nowPosition")] public int NowPosition { get; }
 
-		public DiceMessage(string matchKey, int playerId, int nowPosition)
+		public DiceMessage(string matchKey, int playerId)
 		{
 			MatchKey = matchKey;
 			PlayerId = playerId;
-			NowPosition = nowPosition;
 		}
 
 		public override bool Equals(object? obj)
 		{
 			if (!(obj is DiceMessage di)) return false;
-			return di.MatchKey == MatchKey && di.PlayerId == PlayerId && di.NowPosition == NowPosition;
+			return di.MatchKey == MatchKey && di.PlayerId == PlayerId;
 		}
 	}
 }

--- a/SugorokuLibrary/ClientToServer/DiceMessage.cs
+++ b/SugorokuLibrary/ClientToServer/DiceMessage.cs
@@ -7,15 +7,21 @@ namespace SugorokuLibrary.ClientToServer
 	public class DiceMessage : ClientMessage
 	{
 		[JsonProperty("methodType")] public string MethodType => "dice";
-		[JsonProperty("matchId")] public string MatchId { get; }
+		[JsonProperty("matchKey")] public string MatchKey { get; }
 		[JsonProperty("playerId")] public int PlayerId { get; }
 		[JsonProperty("nowPosition")] public int NowPosition { get; }
 
-		public DiceMessage(string matchId, int playerId, int nowPosition)
+		public DiceMessage(string matchKey, int playerId, int nowPosition)
 		{
-			MatchId = matchId;
+			MatchKey = matchKey;
 			PlayerId = playerId;
 			NowPosition = nowPosition;
+		}
+
+		public override bool Equals(object? obj)
+		{
+			if (!(obj is DiceMessage di)) return false;
+			return di.MatchKey == MatchKey && di.PlayerId == PlayerId && di.NowPosition == NowPosition;
 		}
 	}
 }

--- a/SugorokuLibrary/ClientToServer/PrevDiceMessage.cs
+++ b/SugorokuLibrary/ClientToServer/PrevDiceMessage.cs
@@ -4,18 +4,24 @@ using SugorokuLibrary.ClientToServer.Converters;
 namespace SugorokuLibrary.ClientToServer
 {
     [JsonConverter(typeof(PrevDiceMessageConverter))]
-    public class PrevDiceMessage
+    public class PrevDiceMessage : ClientMessage
     {
-        [JsonProperty("methodType")] public string MethodType => "dice";
-        [JsonProperty("matchId")] public string MatchId { get; }
+        [JsonProperty("methodType")] public string MethodType => "prevDice";
+        [JsonProperty("matchKey")] public string MatchKey { get; }
         [JsonProperty("playerId")] public int PlayerId { get; }
         [JsonProperty("nowPosition")] public int NowPosition { get; }
 
-        public PrevDiceMessage(string matchId, int playerId, int nowPosition)
+        public PrevDiceMessage(string matchKey, int playerId, int nowPosition)
         {
-            MatchId = matchId;
+            MatchKey = matchKey;
             PlayerId = playerId;
             NowPosition = nowPosition;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (!(obj is PrevDiceMessage pr)) return false;
+            return pr.MatchKey == MatchKey && pr.PlayerId == PlayerId && pr.NowPosition == NowPosition;
         }
     }
 }

--- a/SugorokuLibrary/ClientToServer/PrevDiceMessage.cs
+++ b/SugorokuLibrary/ClientToServer/PrevDiceMessage.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+using SugorokuLibrary.ClientToServer.Converters;
+
+namespace SugorokuLibrary.ClientToServer
+{
+    [JsonConverter(typeof(PrevDiceMessageConverter))]
+    public class PrevDiceMessage
+    {
+        [JsonProperty("methodType")] public string MethodType => "dice";
+        [JsonProperty("matchId")] public string MatchId { get; }
+        [JsonProperty("playerId")] public int PlayerId { get; }
+        [JsonProperty("nowPosition")] public int NowPosition { get; }
+
+        public PrevDiceMessage(string matchId, int playerId, int nowPosition)
+        {
+            MatchId = matchId;
+            PlayerId = playerId;
+            NowPosition = nowPosition;
+        }
+    }
+}

--- a/SugorokuLibrary/ClientToServer/PrevDiceMessage.cs
+++ b/SugorokuLibrary/ClientToServer/PrevDiceMessage.cs
@@ -9,19 +9,17 @@ namespace SugorokuLibrary.ClientToServer
         [JsonProperty("methodType")] public string MethodType => "prevDice";
         [JsonProperty("matchKey")] public string MatchKey { get; }
         [JsonProperty("playerId")] public int PlayerId { get; }
-        [JsonProperty("nowPosition")] public int NowPosition { get; }
 
-        public PrevDiceMessage(string matchKey, int playerId, int nowPosition)
+        public PrevDiceMessage(string matchKey, int playerId)
         {
             MatchKey = matchKey;
             PlayerId = playerId;
-            NowPosition = nowPosition;
         }
 
         public override bool Equals(object? obj)
         {
             if (!(obj is PrevDiceMessage pr)) return false;
-            return pr.MatchKey == MatchKey && pr.PlayerId == PlayerId && pr.NowPosition == NowPosition;
+            return pr.MatchKey == MatchKey && pr.PlayerId == PlayerId;
         }
     }
 }

--- a/SugorokuLibrary/ListQueue.cs
+++ b/SugorokuLibrary/ListQueue.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+
+namespace SugorokuLibrary
+{
+    public class ListQueue<T> : List<T>
+    {
+        public void Enqueue(T item)
+        {
+            Add(item);
+        }
+
+        public T Dequeue()
+        {
+            var t = base[0];
+            RemoveAt(0);
+            return t;
+        }
+
+        public T Peek()
+        {
+            return base[0];
+        }
+    }
+}

--- a/SugorokuLibrary/Match/MatchCore.cs
+++ b/SugorokuLibrary/Match/MatchCore.cs
@@ -13,13 +13,13 @@ namespace SugorokuLibrary.Match
 		public MatchInfo MatchInfo { get; set; }
 
 		/// <value> すごろくのマスの情報 </value>
-		public Field Field { get; set; }
+		public Field Field { get; }
 
 		/// <value> プレイヤー情報、プレイヤーIDをKeyとするPlayerクラスの辞書</value>
-		public Dictionary<int, Player> Players { get; set; }
+		public Dictionary<int, Player> Players { get; }
 
 		/// <value> 行動の順番をPlayerIDの並びで格納する(3順分くらい) </value>
-		public ListQueue<int> ActionSchedule { get; set; }
+		public ListQueue<int> ActionSchedule { get; }
 
 		/// <value> 順位を格納する </value>
 		public Queue<int> Ranking { get; private set; }
@@ -48,7 +48,7 @@ namespace SugorokuLibrary.Match
 		/// </summary>
 		/// <param name="matchInfo">事前に準備した試合情報</param>
 		/// <param name="players">プレイヤー情報の配列</param>
-		public MatchCore(MatchInfo matchInfo, Player[] players) : this()
+		public MatchCore(MatchInfo matchInfo, IReadOnlyList<Player> players) : this()
 		{
 			MatchInfo = matchInfo;
 			ResetPlayerInfo(players);
@@ -102,6 +102,7 @@ namespace SugorokuLibrary.Match
 			}
 
 			// イベントの実行
+			Players[playerAction.PlayerID].Position = nextPos;
 			Field.Squares[nextPos].Event.Event(this, MatchInfo.NextPlayerID);
 
 			// 次のターンに進める

--- a/SugorokuLibrary/Match/MatchCore.cs
+++ b/SugorokuLibrary/Match/MatchCore.cs
@@ -19,7 +19,7 @@ namespace SugorokuLibrary.Match
 		public Dictionary<int, Player> Players { get; set; }
 
 		/// <value> 行動の順番をPlayerIDの並びで格納する(3順分くらい) </value>
-		public Queue<int> ActionSchedule { get; set; }
+		public ListQueue<int> ActionSchedule { get; set; }
 
 		/// <value> 順位を格納する </value>
 		public Queue<int> Ranking { get; private set; }
@@ -38,7 +38,7 @@ namespace SugorokuLibrary.Match
 			MatchInfo = new MatchInfo();
 			Field = new Field();
 			Players = new Dictionary<int, Player>();
-			ActionSchedule = new Queue<int>();
+			ActionSchedule = new ListQueue<int>();
 			Ranking = new Queue<int>();
 			Rand = new Random();
 		}
@@ -102,7 +102,7 @@ namespace SugorokuLibrary.Match
 			}
 
 			// イベントの実行
-			Field.Squares[nextPos].Event.Event();
+			Field.Squares[nextPos].Event.Event(this, MatchInfo.NextPlayerID);
 
 			// 次のターンに進める
 			if (ActionSchedule.Count != 0)
@@ -138,21 +138,14 @@ namespace SugorokuLibrary.Match
 		private void Goal(int playerID)
 		{
 			// キューから行動の順番を予定を消す処理
-			var new_schedule = new Queue<int>();
-			foreach (var element in ActionSchedule)
-			{
-				if (element == playerID) continue;
-				new_schedule.Enqueue(element);
-			}
-			ActionSchedule.Clear();
-			ActionSchedule = new_schedule;
+			ActionSchedule.RemoveAll(p => p == playerID);
 
 			// プレイヤーの位置をゴール位置に合わせる
 			Players[playerID].Position = Constants.GoalPosition;
 			Ranking.Enqueue(playerID);
 			
 			// 全プレイヤーがゴールしたので、終了処理に移る
-			if (new_schedule.Count == 0)
+			if (ActionSchedule.Count == 0)
 			{
 				End();
 			}
@@ -183,7 +176,7 @@ namespace SugorokuLibrary.Match
 		/// </summary>
 		/// <param name="schedule">PlayerIDの並びで行動の順番を格納するキュー</param>
 		/// <param name="players">Player情報の配列、この配列の順番が行動の順番となる</param>
-		private static void ResetActionSchedule(Queue<int> schedule, IReadOnlyList<Player> players)
+		private static void ResetActionSchedule(ListQueue<int> schedule, IReadOnlyList<Player> players)
 		{
 			schedule.Clear();
 			for (var i = 0; i < players.Count * 3; i++)

--- a/SugorokuLibrary/Protocol/HeaderProtocol.cs
+++ b/SugorokuLibrary/Protocol/HeaderProtocol.cs
@@ -26,7 +26,7 @@ namespace SugorokuLibrary.Protocol
 			var lines = msg.Split("\n");
 			var headerSplit = lines[0].Split(',');
 			var (sizeStr, functionSuccess, bodyLines) = (headerSplit[0], headerSplit[1], string.Concat(lines.Skip(1)));
-			return (int.Parse(sizeStr) + sizeStr.Length + 1, functionSuccess == "OK", bodyLines);
+			return (int.Parse(sizeStr), functionSuccess == "OK", bodyLines);
 		}
 	}
 }

--- a/SugorokuLibrary/SquareEvents/DiceAgainEvent.cs
+++ b/SugorokuLibrary/SquareEvents/DiceAgainEvent.cs
@@ -1,10 +1,12 @@
+using SugorokuLibrary.Match;
+
 namespace SugorokuLibrary.SquareEvents
 {
     public class DiceAgainEvent : ISquareEvent
     {
-        public void Event()
+        public void Event(MatchCore matchCore, int playerId)
         {
-            throw new System.NotImplementedException();
+            matchCore.ActionSchedule.Insert(0, playerId);
         }
     }
 }

--- a/SugorokuLibrary/SquareEvents/DiceAgainEvent.cs
+++ b/SugorokuLibrary/SquareEvents/DiceAgainEvent.cs
@@ -8,5 +8,10 @@ namespace SugorokuLibrary.SquareEvents
         {
             matchCore.ActionSchedule.Insert(0, playerId);
         }
+
+        public override string ToString()
+        {
+            return "DiceAgain";
+        }
     }
 }

--- a/SugorokuLibrary/SquareEvents/GoStartEvent.cs
+++ b/SugorokuLibrary/SquareEvents/GoStartEvent.cs
@@ -8,5 +8,10 @@ namespace SugorokuLibrary.SquareEvents
         {
             matchCore.Players[playerId].Position = 0;
         }
+
+        public override string ToString()
+        {
+            return "GoStart";
+        }
     }
 }

--- a/SugorokuLibrary/SquareEvents/GoStartEvent.cs
+++ b/SugorokuLibrary/SquareEvents/GoStartEvent.cs
@@ -1,10 +1,12 @@
+using SugorokuLibrary.Match;
+
 namespace SugorokuLibrary.SquareEvents
 {
     public class GoStartEvent : ISquareEvent
     {
-        public void Event()
+        public void Event(MatchCore matchCore, int playerId)
         {
-            throw new System.NotImplementedException();
+            matchCore.Players[playerId].Position = 0;
         }
     }
 }

--- a/SugorokuLibrary/SquareEvents/ISquareEvent.cs
+++ b/SugorokuLibrary/SquareEvents/ISquareEvent.cs
@@ -1,7 +1,9 @@
+using SugorokuLibrary.Match;
+
 namespace SugorokuLibrary.SquareEvents
 {
     public interface ISquareEvent
     {
-        public void Event();
+        public void Event(MatchCore matchCore, int playerId);
     }
 }

--- a/SugorokuLibrary/SquareEvents/NextEvent.cs
+++ b/SugorokuLibrary/SquareEvents/NextEvent.cs
@@ -1,12 +1,13 @@
+using SugorokuLibrary.Match;
+
 namespace SugorokuLibrary.SquareEvents
 {
     public class NextEvent : ISquareEvent
     {
         public int NextCount { get; set; }
-
-        public void Event()
+        public void Event(MatchCore matchCore, int playerId)
         {
-            throw new System.NotImplementedException();
+            matchCore.Players[playerId].Position += NextCount;
         }
     }
 }

--- a/SugorokuLibrary/SquareEvents/NextEvent.cs
+++ b/SugorokuLibrary/SquareEvents/NextEvent.cs
@@ -9,5 +9,10 @@ namespace SugorokuLibrary.SquareEvents
         {
             matchCore.Players[playerId].Position += NextCount;
         }
+
+        public override string ToString()
+        {
+            return $"Next {NextCount}";
+        }
     }
 }

--- a/SugorokuLibrary/SquareEvents/NoneEvent.cs
+++ b/SugorokuLibrary/SquareEvents/NoneEvent.cs
@@ -7,5 +7,10 @@ namespace SugorokuLibrary.SquareEvents
         public void Event(MatchCore matchCore, int playerId)
         {
         }
+
+        public override string ToString()
+        {
+            return "None";
+        }
     }
 }

--- a/SugorokuLibrary/SquareEvents/NoneEvent.cs
+++ b/SugorokuLibrary/SquareEvents/NoneEvent.cs
@@ -1,8 +1,10 @@
+using SugorokuLibrary.Match;
+
 namespace SugorokuLibrary.SquareEvents
 {
     public class NoneEvent : ISquareEvent
     {
-        public void Event()
+        public void Event(MatchCore matchCore, int playerId)
         {
         }
     }

--- a/SugorokuLibrary/SquareEvents/PrevDiceEvent.cs
+++ b/SugorokuLibrary/SquareEvents/PrevDiceEvent.cs
@@ -1,10 +1,12 @@
+using SugorokuLibrary.Match;
+
 namespace SugorokuLibrary.SquareEvents
 {
     public class PrevDiceEvent : ISquareEvent
     {
-        public void Event()
+        public void Event(MatchCore matchCore, int playerId)
         {
-            throw new System.NotImplementedException();
+            matchCore.ActionSchedule.Insert(0, playerId);
         }
     }
 }

--- a/SugorokuLibrary/SquareEvents/PrevDiceEvent.cs
+++ b/SugorokuLibrary/SquareEvents/PrevDiceEvent.cs
@@ -8,5 +8,10 @@ namespace SugorokuLibrary.SquareEvents
         {
             matchCore.ActionSchedule.Insert(0, playerId);
         }
+
+        public override string ToString()
+        {
+            return "PrevDice";
+        }
     }
 }

--- a/SugorokuLibrary/SquareEvents/PrevEvent.cs
+++ b/SugorokuLibrary/SquareEvents/PrevEvent.cs
@@ -10,5 +10,10 @@ namespace SugorokuLibrary.SquareEvents
         {
             matchCore.Players[playerId].Position -= BackCount;
         }
+
+        public override string ToString()
+        {
+            return $"Prev {BackCount}";
+        }
     }
 }

--- a/SugorokuLibrary/SquareEvents/PrevEvent.cs
+++ b/SugorokuLibrary/SquareEvents/PrevEvent.cs
@@ -1,12 +1,14 @@
+using SugorokuLibrary.Match;
+
 namespace SugorokuLibrary.SquareEvents
 {
     public class PrevEvent : ISquareEvent
     {
         public int BackCount { get; set; }
 
-        public void Event()
+        public void Event(MatchCore matchCore, int playerId)
         {
-            throw new System.NotImplementedException();
+            matchCore.Players[playerId].Position -= BackCount;
         }
     }
 }

--- a/SugorokuLibrary/SquareEvents/WaitEvent.cs
+++ b/SugorokuLibrary/SquareEvents/WaitEvent.cs
@@ -1,10 +1,12 @@
+using SugorokuLibrary.Match;
+
 namespace SugorokuLibrary.SquareEvents
 {
     public class WaitEvent : ISquareEvent
     {
-        public void Event()
+        public void Event(MatchCore matchCore, int playerId)
         {
-            throw new System.NotImplementedException();
+            matchCore.ActionSchedule.Remove(playerId);
         }
     }
 }

--- a/SugorokuLibrary/SquareEvents/WaitEvent.cs
+++ b/SugorokuLibrary/SquareEvents/WaitEvent.cs
@@ -8,5 +8,10 @@ namespace SugorokuLibrary.SquareEvents
         {
             matchCore.ActionSchedule.Remove(playerId);
         }
+
+        public override string ToString()
+        {
+            return "Wait";
+        }
     }
 }

--- a/SugorokuServer.Tests/LibraryTest.cs
+++ b/SugorokuServer.Tests/LibraryTest.cs
@@ -81,17 +81,17 @@ namespace SugorokuServer.Tests
 			new object[]
 			{
 				"{\"methodType\":\"dice\",\"playerId\":0,\"nowPosition\":3,\"matchKey\":\"abc\"}",
-				new DiceMessage("abc", 0, 3)
+				new DiceMessage("abc", 0)
 			},
 			new object[]
 			{
 				"{\"methodType\":\"prevDice\",\"playerId\":0,\"nowPosition\":7,\"matchKey\":\"abc\"}",
-				new PrevDiceMessage("abc", 0, 7)
+				new PrevDiceMessage("abc", 0)
 			}
 		};
 
 		[TestCaseSource(nameof(JsonParseTestCases))]
-		public void JsonテキストからCSharpクラスにコンバートできるかテスト(string jsonText, ClientMessage exp)
+		public void JsonテキストからCsharpクラスにコンバートできるかテスト(string jsonText, ClientMessage exp)
 		{
 			var parsed = JsonConvert.DeserializeObject<ClientMessage>(jsonText);
 			Assert.AreEqual(exp, parsed);

--- a/SugorokuServer.Tests/LibraryTest.cs
+++ b/SugorokuServer.Tests/LibraryTest.cs
@@ -1,5 +1,8 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using SugorokuLibrary;
+using SugorokuLibrary.ClientToServer;
 using SugorokuLibrary.SquareEvents;
 
 namespace SugorokuServer.Tests
@@ -65,6 +68,41 @@ namespace SugorokuServer.Tests
 					Assert.AreEqual(((NextEvent) expEvent).NextCount, n.NextCount);
 					break;
 			}
+		}
+
+		private static readonly object[] JsonParseTestCases =
+		{
+			new object[] {"{\"methodType\":\"closeCreate\",\"matchKey\":\"abc\"}", new CloseCreateMessage("abc")},
+			new object[]
+			{
+				"{\"methodType\":\"createPlayer\",\"playerName\":\"ばぬし\",\"matchKey\":\"abc\"}",
+				new CreatePlayerMessage("ばぬし", "abc")
+			},
+			new object[]
+			{
+				"{\"methodType\":\"dice\",\"playerId\":0,\"nowPosition\":3,\"matchKey\":\"abc\"}",
+				new DiceMessage("abc", 0, 3)
+			},
+			new object[]
+			{
+				"{\"methodType\":\"prevDice\",\"playerId\":0,\"nowPosition\":7,\"matchKey\":\"abc\"}",
+				new PrevDiceMessage("abc", 0, 7)
+			}
+		};
+
+		[TestCaseSource(nameof(JsonParseTestCases))]
+		public void JsonテキストからCSharpクラスにコンバートできるかテスト(string jsonText, ClientMessage exp)
+		{
+			var parsed = JsonConvert.DeserializeObject<ClientMessage>(jsonText);
+			Assert.AreEqual(exp, parsed);
+		}
+
+		[TestCaseSource(nameof(JsonParseTestCases))]
+		public void CSharpクラスからJsonテキストにコンバートできるかテスト(string exp, ClientMessage abc)
+		{
+			var text = JsonConvert.SerializeObject(abc);
+			Assert.AreEqual(JsonConvert.DeserializeObject<Dictionary<string, object>>(exp),
+				JsonConvert.DeserializeObject<Dictionary<string, object>>(text));
 		}
 	}
 }

--- a/SugorokuServer.Tests/PlayTest.cs
+++ b/SugorokuServer.Tests/PlayTest.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using NUnit.Framework;
 using SugorokuLibrary.ClientToServer;
+using SugorokuLibrary.Protocol;
 
 namespace SugorokuServer.Tests
 {
@@ -18,37 +19,58 @@ namespace SugorokuServer.Tests
         {
             new object[]
             {
-                JsonConvert.SerializeObject(new CreatePlayerMessage("ばぬし", "1")),
+                JsonConvert.SerializeObject(new CreatePlayerMessage("ばぬし", "aaa")),
                 true
             },
             new object[]
             {
-                JsonConvert.SerializeObject(new CreatePlayerMessage("ねこ", "1")),
+                JsonConvert.SerializeObject(new CreatePlayerMessage("ねこ", "aaa")),
                 true
             },
             new object[]
             {
-                JsonConvert.SerializeObject(new CloseCreateMessage("1")),
+                JsonConvert.SerializeObject(new CloseCreateMessage("aaa")),
                 true
             },
             new object[]
             {
-                JsonConvert.SerializeObject(new CreatePlayerMessage("いぬ", "1")),
+                JsonConvert.SerializeObject(new CreatePlayerMessage("いぬ", "aaa")),
                 false
             },
             new object[]
             {
-                JsonConvert.SerializeObject(new DiceMessage("1", 1, 0)),
+                JsonConvert.SerializeObject(new DiceMessage("aaa", 1)),
                 true
             },
             new object[]
             {
-                JsonConvert.SerializeObject(new DiceMessage("1", 1, 0)),
+                JsonConvert.SerializeObject(new DiceMessage("aaa", 1)),
                 false
             },
             new object[]
             {
-                JsonConvert.SerializeObject(new DiceMessage("1", 2, 0)),
+                JsonConvert.SerializeObject(new DiceMessage("aaa", 2)),
+                true
+            },
+            new object[]
+            {
+                JsonConvert.SerializeObject(new DiceMessage("aaa", 1)),
+                true
+            },
+            new object[]
+            {
+                JsonConvert.SerializeObject(new DiceMessage("aaa", 2)),
+                true
+            },
+            
+            new object[]
+            {
+                JsonConvert.SerializeObject(new DiceMessage("aaa", 1)),
+                true
+            },
+            new object[]
+            {
+                JsonConvert.SerializeObject(new DiceMessage("aaa", 2)),
                 true
             }
         };
@@ -58,7 +80,7 @@ namespace SugorokuServer.Tests
         {
             var sendingMsg = _handleClient.MakeSendMessage(receivedMsg);
             Console.WriteLine(sendingMsg);
-            var (bufSize, isTrueMessage, msg) = SugorokuLibrary.Protocol.HeaderProtocol.ParseHeader(sendingMsg);
+            var (bufSize, isTrueMessage, msg) = HeaderProtocol.ParseHeader(sendingMsg);
             Assert.AreEqual(bufSize, msg.Length);
             Assert.AreEqual(exp, isTrueMessage);
         }

--- a/SugorokuServer.Tests/PlayTest.cs
+++ b/SugorokuServer.Tests/PlayTest.cs
@@ -15,43 +15,59 @@ namespace SugorokuServer.Tests
             _handleClient = new HandleClient();
         }
 
+        // サーバーに送る通信要求のbody文字列はClientToServerにあるクラスのインスタンスを作成し
+        // それをSerializeObject()すると作成できます。
+        // 作成できたbodyをLibrary/Protocol/HeaderProtocol.MakeHeader(body, true)で投げて
+        // 返った文字列を送信してください。
         private static object[] _sugorokuPlayTestCase =
         {
+            // CreatePlayerMessage は2引数に取る文字列(MatchKey)で開かれている部屋があればそこに参加、
+            // なければその部屋名で新規の参加を待ちます。
+            // ばぬしで生成した Player.cs インスタンスをシリアライズした文字列がbodyで返るので
+            // デシリアライズしたものをClientで持っておいてください
             new object[]
             {
                 JsonConvert.SerializeObject(new CreatePlayerMessage("ばぬし", "aaa")),
                 true
             },
+            // aaaという部屋は↑で作成されているので「ねこ」はその部屋に参加します
             new object[]
             {
                 JsonConvert.SerializeObject(new CreatePlayerMessage("ねこ", "aaa")),
                 true
             },
+            // aaaという部屋の新規のプレイヤーの参加を締め切ります。
+            // (TODO このメッセージを送ったのが「ばぬし」かどうかの判定はまだ書いていません)
             new object[]
             {
                 JsonConvert.SerializeObject(new CloseCreateMessage("aaa")),
                 true
             },
+            // aaaという部屋の新規の参加は↑で締め切られているので「いぬ」は参加できません
             new object[]
             {
                 JsonConvert.SerializeObject(new CreatePlayerMessage("いぬ", "aaa")),
                 false
             },
+            // サイコロを振る要求を飛ばします。(playerId: 1 は「ばぬし」)
             new object[]
             {
                 JsonConvert.SerializeObject(new DiceMessage("aaa", 1)),
                 true
             },
+            // ↑で「ばぬし」がサイコロを振ったはずなのでplayer:1のターンではない→false
             new object[]
             {
                 JsonConvert.SerializeObject(new DiceMessage("aaa", 1)),
                 false
             },
+            // 「ねこ」がサイコロを振る要求
             new object[]
             {
                 JsonConvert.SerializeObject(new DiceMessage("aaa", 2)),
                 true
             },
+            // 以下「一回休み」が出た場合はtrueでない値になるためテスト失敗の可能性あり
             new object[]
             {
                 JsonConvert.SerializeObject(new DiceMessage("aaa", 1)),

--- a/SugorokuServer.Tests/PlayTest.cs
+++ b/SugorokuServer.Tests/PlayTest.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using SugorokuLibrary.ClientToServer;
+
+namespace SugorokuServer.Tests
+{
+    public class PlayTest
+    {
+        private HandleClient _handleClient;
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            _handleClient = new HandleClient();
+        }
+
+        private static object[] _sugorokuPlayTestCase =
+        {
+            new object[]
+            {
+                JsonConvert.SerializeObject(new CreatePlayerMessage("ばぬし", "1")),
+                true
+            },
+            new object[]
+            {
+                JsonConvert.SerializeObject(new CreatePlayerMessage("ねこ", "1")),
+                true
+            },
+            new object[]
+            {
+                JsonConvert.SerializeObject(new CloseCreateMessage("1")),
+                true
+            },
+            new object[]
+            {
+                JsonConvert.SerializeObject(new CreatePlayerMessage("いぬ", "1")),
+                false
+            },
+            new object[]
+            {
+                JsonConvert.SerializeObject(new DiceMessage("1", 1, 0)),
+                true
+            },
+            new object[]
+            {
+                JsonConvert.SerializeObject(new DiceMessage("1", 1, 0)),
+                false
+            },
+            new object[]
+            {
+                JsonConvert.SerializeObject(new DiceMessage("1", 2, 0)),
+                true
+            }
+        };
+
+        [TestCaseSource(nameof(_sugorokuPlayTestCase))]
+        public void GamePlayingTest(string receivedMsg, bool exp)
+        {
+            var sendingMsg = _handleClient.MakeSendMessage(receivedMsg);
+            Console.WriteLine(sendingMsg);
+            var (bufSize, isTrueMessage, msg) = SugorokuLibrary.Protocol.HeaderProtocol.ParseHeader(sendingMsg);
+            Assert.AreEqual(bufSize, msg.Length);
+            Assert.AreEqual(exp, isTrueMessage);
+        }
+    }
+}

--- a/SugorokuServer/HandleClient.cs
+++ b/SugorokuServer/HandleClient.cs
@@ -87,7 +87,7 @@ namespace SugorokuServer
 			matchInfo.ReflectAction(action);
 			_startedMatch[diceMessage.MatchKey] = matchInfo;
 
-			return (true, $"{dice}");
+			return (true, $"{dice} {matchInfo.Players[diceMessage.PlayerId].Position}");
 		}
 
 		private static int Dice()
@@ -169,6 +169,7 @@ namespace SugorokuServer
 			match.StartAtUnixTime = DateTime.Now.ToTimeStamp();
 			match.Turn = 0;
 			_startedMatch.Add(message.MatchKey, new MatchCore(match));
+			_startedMatch[message.MatchKey].Start();
 			return (true, JsonConvert.SerializeObject(_matches[message.MatchKey], _settings));
 		}
 

--- a/SugorokuServer/HandleClient.cs
+++ b/SugorokuServer/HandleClient.cs
@@ -72,7 +72,7 @@ namespace SugorokuServer
 
 		private (bool, string) ThrowDice(DiceMessage diceMessage)
 		{
-			var matchInfo = _startedMatch[diceMessage.MatchId];
+			var matchInfo = _startedMatch[diceMessage.MatchKey];
 			if (matchInfo.ActionSchedule.Peek() != diceMessage.PlayerId)
 			{
 				return (false, "まだあなたのターンではありません");
@@ -85,7 +85,7 @@ namespace SugorokuServer
 				Length = dice
 			};
 			matchInfo.ReflectAction(action);
-			_startedMatch[diceMessage.MatchId] = matchInfo;
+			_startedMatch[diceMessage.MatchKey] = matchInfo;
 
 			return (true, $"{dice}");
 		}

--- a/SugorokuServer/HandleClient.cs
+++ b/SugorokuServer/HandleClient.cs
@@ -87,7 +87,8 @@ namespace SugorokuServer
 			matchInfo.ReflectAction(action);
 			_startedMatch[diceMessage.MatchKey] = matchInfo;
 
-			return (true, $"{dice} {matchInfo.Players[diceMessage.PlayerId].Position}");
+			var pos = matchInfo.Players[diceMessage.PlayerId].Position;
+			return (true, $"{dice} {pos} {Field.Squares[pos].Event}");
 		}
 
 		private static int Dice()


### PR DESCRIPTION
## 概要

以下の内容について記述しました

1. すごろくを振る要求を受け取ったときのサーバーの動作について実装 (#6 共通→必須項目 Checkbox No:3~6)
1. `Queue<int>` で実装されていた部分について新規に `ListQueue<int>` を作成し実装変更

## 詳細

### 1.について

クライアントサイドから送信された `Newtonsoft.Json.JsonConvert.SerializeObject(new DiceMessage(...))` で生成されるstring文字列を受け取ると

```
{2行目以降送信の内容(ボディ)のサイズ},{自分のターンであれば「OK」、まだであれば「FAIL」}
{このターンで出たサイコロの値} {移動したあとのマスのイベントも反映した位置(Prev/Nextも反映)} {マスのイベント} [{Prev/Nextだったときの移動数}]
```

という形式で返信します。

具体的には、(以下、自分のターンでClientが要求を飛ばし、スタート地点(None)から5(Next +3)を出したときのServerが返す文字列)

```
10,OK
5 8 Next 3
```

のような形です。


### 2. について

`SugorokuLibrary/ListQueue.cs` にて、Queue<T>が実装する「Enqueue」「Dequeue」「Peek」をList<T>で仮想的に実装した`ListQueue<T>` を実装しました。これにより、Queueの上記3つを利用できる環境ながらListの「Insert」「Remove」なども使用可能になります。

`SugorokuLibrary/Match/MatchCore.cs` に利用されていた `ActionSchedule` はこちらを利用したものに書き換えました。


## クライアントサイドで実装してほしいもの

`SugorokuServer.Tests/PlayTest.cs` に記載されているテストケースのような流れで通信要求が飛んでくることを想定しています。

気になった点があればいつでも連絡ください。