### PR TITLE
クライアント・サーバーの送受信関数の作成

### DIFF
--- a/SugorokuLibrary/Protocol/Connection.cs
+++ b/SugorokuLibrary/Protocol/Connection.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text;
+
+namespace SugorokuLibrary.Protocol
+{
+	public static class Connection
+	{
+		private const int MaxSize = 1024;
+
+		private static (int, bool, string) Receive(Socket partnerSocket)
+		{
+			var buf = new byte[MaxSize];
+			var receivedMessages = new List<byte>();
+			var receivedSize = partnerSocket.Receive(buf);
+			if (receivedSize == 0)
+			{
+				Console.WriteLine("ZERO!!!!!!!!");
+			}
+			receivedMessages.AddRange(buf);
+			var headerBytes = buf.TakeWhile(b => b != '\n').ToList();
+			var (bodySize, result) = HeaderProtocol.AnalyzeHeader(Encoding.UTF8.GetString(headerBytes.ToArray()));
+
+			while (receivedSize < bodySize)
+			{
+				buf = new byte[MaxSize];
+				receivedSize += partnerSocket.Receive(buf, receivedSize, MaxSize - receivedSize, SocketFlags.None);
+				receivedMessages.AddRange(buf);
+			}
+
+			var msg = Encoding.UTF8.GetString(receivedMessages.TakeWhile(b => b != 0).ToArray());
+			return (bodySize, result, msg);
+		}
+
+		private static void Send(string message, Socket partnerSocket)
+		{
+			var sendSize = 0;
+			while (sendSize < message.Length)
+			{
+				var startSelected = message[sendSize..];
+				Console.WriteLine(startSelected);
+				sendSize += partnerSocket.Send(Encoding.UTF8.GetBytes(startSelected));
+			}
+		}
+
+		public static (int, bool, string) SendAndRecvMessage(string message, Socket partnerSocket)
+		{
+			Send(message, partnerSocket);
+			return Receive(partnerSocket);
+		}
+
+		public static void RecvAndSendMessage(string message, Socket partnerSocket)
+		{
+			Send(message, partnerSocket);
+		}
+	}
+}

--- a/SugorokuLibrary/Protocol/HeaderProtocol.cs
+++ b/SugorokuLibrary/Protocol/HeaderProtocol.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 
 namespace SugorokuLibrary.Protocol
@@ -12,7 +13,9 @@ namespace SugorokuLibrary.Protocol
 		/// <returns></returns>
 		public static string MakeHeader(string bodyMessage, bool methodSuccess)
 		{
-			return $"{bodyMessage.Length},{(methodSuccess ? "OK" : "FAIL")}\n{bodyMessage}";
+			var bodyLength = bodyMessage.Length;
+			var headerLength = bodyLength.ToString().Length + (methodSuccess ? 4 : 6);
+			return $"{headerLength + bodyLength},{(methodSuccess ? "OK" : "FAIL")}\n{bodyMessage}";
 		}
 
 		/// <summary>
@@ -26,7 +29,15 @@ namespace SugorokuLibrary.Protocol
 			var lines = msg.Split("\n");
 			var headerSplit = lines[0].Split(',');
 			var (sizeStr, functionSuccess, bodyLines) = (headerSplit[0], headerSplit[1], string.Concat(lines.Skip(1)));
-			return (int.Parse(sizeStr), functionSuccess == "OK", bodyLines);
+			return (int.Parse(sizeStr) + lines[0].Length + 1, functionSuccess == "OK", bodyLines);
+		}
+
+		public static (int, bool) AnalyzeHeader(string header)
+		{
+			var headerSplit = header.Split(',');
+
+			Console.WriteLine($"Parsing Size: {headerSplit[0]}");
+			return (int.Parse(headerSplit[0]), headerSplit[1] == "OK");
 		}
 	}
 }

--- a/SugorokuLibrary/Protocol/HeaderProtocol.cs
+++ b/SugorokuLibrary/Protocol/HeaderProtocol.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Text;
 
 namespace SugorokuLibrary.Protocol
 {
@@ -13,7 +14,7 @@ namespace SugorokuLibrary.Protocol
 		/// <returns></returns>
 		public static string MakeHeader(string bodyMessage, bool methodSuccess)
 		{
-			var bodyLength = bodyMessage.Length;
+			var bodyLength = Encoding.UTF8.GetByteCount(bodyMessage);
 			var headerLength = bodyLength.ToString().Length + (methodSuccess ? 4 : 6);
 			return $"{headerLength + bodyLength},{(methodSuccess ? "OK" : "FAIL")}\n{bodyMessage}";
 		}

--- a/SugorokuServer.Tests/ServerConnectionTest.cs
+++ b/SugorokuServer.Tests/ServerConnectionTest.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Net.Sockets;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using SugorokuLibrary.ClientToServer;
+using SugorokuLibrary.Protocol;
+
+namespace SugorokuServer.Tests
+{
+    public class ServerConnectionTest
+    {
+        private Socket _socket;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            // Program.Main(new string[] { });
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            _socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            _socket.Connect("127.0.0.1", 9500);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _socket.Close();
+        }
+
+        private static object[] _sugorokuPlayTestCase =
+        {
+            // CreatePlayerMessage は2引数に取る文字列(MatchKey)で開かれている部屋があればそこに参加、
+            // なければその部屋名で新規の参加を待ちます。
+            // ばぬしで生成した Player.cs インスタンスをシリアライズした文字列がbodyで返るので
+            // デシリアライズしたものをClientで持っておいてください
+            new object[]
+            {
+                JsonConvert.SerializeObject(new CreatePlayerMessage("ばぬし", "aaa")),
+                true
+            },
+            // aaaという部屋は↑で作成されているので「ねこ」はその部屋に参加します
+            new object[]
+            {
+                JsonConvert.SerializeObject(new CreatePlayerMessage("ねこ", "aaa")),
+                true
+            },
+            // aaaという部屋の新規のプレイヤーの参加を締め切ります。
+            new object[]
+            {
+                JsonConvert.SerializeObject(new CloseCreateMessage("aaa")),
+                true
+            },
+            // aaaという部屋の新規の参加は↑で締め切られているので「いぬ」は参加できません
+            new object[]
+            {
+                JsonConvert.SerializeObject(new CreatePlayerMessage("いぬ", "aaa")),
+                false
+            },
+            // サイコロを振る要求を飛ばします。(playerId: 1 は「ばぬし」)
+            new object[]
+            {
+                JsonConvert.SerializeObject(new DiceMessage("aaa", 1)),
+                true
+            },
+            // ↑で「ばぬし」がサイコロを振ったはずなのでplayer:1のターンではない→false
+            new object[]
+            {
+                JsonConvert.SerializeObject(new DiceMessage("aaa", 1)),
+                false
+            },
+            // 「ねこ」がサイコロを振る要求
+            new object[]
+            {
+                JsonConvert.SerializeObject(new DiceMessage("aaa", 2)),
+                true
+            },
+            // 以下「一回休み」が出た場合はtrueでない値になるためテスト失敗の可能性あり
+            new object[]
+            {
+                JsonConvert.SerializeObject(new DiceMessage("aaa", 1)),
+                true
+            },
+            new object[]
+            {
+                JsonConvert.SerializeObject(new DiceMessage("aaa", 2)),
+                true
+            },
+            new object[]
+            {
+                JsonConvert.SerializeObject(new DiceMessage("aaa", 1)),
+                true
+            },
+            new object[]
+            {
+                JsonConvert.SerializeObject(new DiceMessage("aaa", 2)),
+                true
+            }
+        };
+
+        [TestCaseSource(nameof(_sugorokuPlayTestCase))]
+        public void ああああ(string input, bool exp)
+        {
+            var withHeader = HeaderProtocol.MakeHeader(input, true);
+            var (s, r, m) = Connection.SendAndRecvMessage(withHeader, _socket);
+            Console.WriteLine($"{s} {r} {m}");
+        }
+    }
+}

--- a/SugorokuServer.Tests/ServerSideTest.cs
+++ b/SugorokuServer.Tests/ServerSideTest.cs
@@ -23,7 +23,7 @@ namespace SugorokuServer.Tests
 			_handleClient = new HandleClient();
 		}
 
-		private static object[] _testCases =
+		private static readonly object[] TestCases =
 		{
 			new object[]
 			{
@@ -70,7 +70,7 @@ namespace SugorokuServer.Tests
 		[Test]
 		public void 作ったマッチが保持されてるか確認するテスト()
 		{
-			var create1 = (string) ((object[])_testCases[0])[0];
+			var create1 = (string) ((object[])TestCases[0])[0];
 			_handleClient.MakeSendMessage(create1);
 			var request = JsonConvert.SerializeObject(new GetAllMatchesMessage());
 			var response = _handleClient.MakeSendMessage(request);
@@ -78,24 +78,13 @@ namespace SugorokuServer.Tests
 			var (_, _, body) = HeaderProtocol.ParseHeader(response);
 			Console.WriteLine(body);
 			
-			var create2 = (string) ((object[])_testCases[1])[0];
+			var create2 = (string) ((object[])TestCases[1])[0];
 			_handleClient.MakeSendMessage(create2);
 			request = JsonConvert.SerializeObject(new GetAllMatchesMessage());
 			response = _handleClient.MakeSendMessage(request);
 
 			(_, _, body) = HeaderProtocol.ParseHeader(response);
 			Console.WriteLine(body);
-		}
-
-		[TestCaseSource(nameof(_testCases))]
-		public void CreatePlayerTest(string inputMsg, Player exp)
-		{
-			var respondMessage = _handleClient.MakeSendMessage(inputMsg);
-			var (_, _, body) = HeaderProtocol.ParseHeader(respondMessage);
-
-			var deserialized = JsonConvert.DeserializeObject<Player>(body, Settings);
-
-			Assert.AreEqual(exp, deserialized);
 		}
 	}
 }

--- a/SugorokuServer/HandleClient.cs
+++ b/SugorokuServer/HandleClient.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
-using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using SugorokuLibrary;
@@ -30,21 +29,13 @@ namespace SugorokuServer
 		/// <returns>受信したメッセージのbody</returns>
 		public static string ReceiveMessage(Socket clientSocket)
 		{
-			var buf = new byte[RecvBufSize];
-			var recvSize = clientSocket.Receive(buf, RecvBufSize, SocketFlags.None);
-			var msg = Encoding.UTF8.GetString(buf).TrimEnd('\0');
-			var (msgSize, _, body) = HeaderProtocol.ParseHeader(msg);
-
+			var (_, _, body) = Connection.Receive(clientSocket);
 			return body;
 		}
 
 		public static void SendMessage(Socket clientSocket, string message)
 		{
-			var sentAllBytes = clientSocket.Send(Encoding.UTF8.GetBytes(message));
-			while (sentAllBytes < message.Length)
-			{
-				sentAllBytes += clientSocket.Send(Encoding.UTF8.GetBytes(message[sentAllBytes..]));
-			}
+			Connection.Send(message, clientSocket);
 		}
 
 		public string MakeSendMessage(string receivedMessage)

--- a/SugorokuServer/HandleClient.cs
+++ b/SugorokuServer/HandleClient.cs
@@ -32,15 +32,8 @@ namespace SugorokuServer
 		{
 			var buf = new byte[RecvBufSize];
 			var recvSize = clientSocket.Receive(buf, RecvBufSize, SocketFlags.None);
-			var msg = Encoding.UTF8.GetString(buf);
+			var msg = Encoding.UTF8.GetString(buf).TrimEnd('\0');
 			var (msgSize, _, body) = HeaderProtocol.ParseHeader(msg);
-
-			while (recvSize >= msgSize)
-			{
-				buf = new byte[RecvBufSize];
-				recvSize += clientSocket.Receive(buf);
-				msg += Encoding.UTF8.GetString(buf);
-			}
 
 			return body;
 		}
@@ -48,7 +41,7 @@ namespace SugorokuServer
 		public static void SendMessage(Socket clientSocket, string message)
 		{
 			var sentAllBytes = clientSocket.Send(Encoding.UTF8.GetBytes(message));
-			while (sentAllBytes >= message.Length)
+			while (sentAllBytes < message.Length)
 			{
 				sentAllBytes += clientSocket.Send(Encoding.UTF8.GetBytes(message[sentAllBytes..]));
 			}

--- a/SugorokuServer/Program.cs
+++ b/SugorokuServer/Program.cs
@@ -24,6 +24,7 @@ namespace SugorokuServer
 			var sendMsg = handleClient.MakeSendMessage(recvMsg);
 
 			HandleClient.SendMessage(clientSocket, sendMsg);
+			clientSocket.Close();
 		}
 	}
 }


### PR DESCRIPTION
## はじめに

バグ修正の側面が大きいため今回のPRは変更記録の扱いとし、即時マージさせていただきます

## 概要

- ヘッダの付与情報の更新
- send / recv 用の関数の作成

### ヘッダ付与情報の更新

#9 にて定義したヘッダ(1行目)に付与される数値情報について、以前はbody(2行目以降)の文字数だったところを、ヘッダも含めたすべての送受信メッセージの「バイト数」と変更しました。これはSocket.Receive()の返り値がバイト数となり、日本語などの2バイト文字を送受信するときの扱いやすさを鑑みたものです。

### send / recv 用の関数の作成

`SugorokuLibrary/Protocol/Connection.cs` にメッセージ送受信のための関数を作成しました。
クライアント側でサーバー側に送るメッセージの作成ができた場合、`SendAndRecvMessage(messageWithHeader, serverSocket)` と関数を実行することでメッセージの送信が可能となります。